### PR TITLE
Custom fake stripe work, porting over to Homechef repo

### DIFF
--- a/lib/fake_stripe/fixtures/capture_charge.json
+++ b/lib/fake_stripe/fixtures/capture_charge.json
@@ -39,6 +39,13 @@
       "balance_transaction": "txn_3ewdvdDggQXEhV"
     }
   ],
+  "outcome": {
+    "network_status": "approved_by_network",
+    "reason": null,
+    "risk_level": "normal",
+    "seller_message": "Payment complete.",
+    "type": "authorized"
+  },
   "balance_transaction": "txn_103cQg2eZvKYlo2CYKVlR2nh",
   "failure_message": null,
   "failure_code": null,

--- a/lib/fake_stripe/fixtures/capture_charge.json
+++ b/lib/fake_stripe/fixtures/capture_charge.json
@@ -27,7 +27,7 @@
     "cvc_check": "pass",
     "dynamic_last4": null,
     "address_line1_check": null,
-    "address_zip_check": null
+    "address_zip_check": "pass"
   },
   "captured": true,
   "refunds": [

--- a/lib/fake_stripe/fixtures/create_card.json
+++ b/lib/fake_stripe/fixtures/create_card.json
@@ -18,5 +18,5 @@
   "cvc_check": null,
   "dynamic_last4": null,
   "address_line1_check": null,
-  "address_zip_check": null
+  "address_zip_check": "pass"
 }

--- a/lib/fake_stripe/fixtures/create_charge.json
+++ b/lib/fake_stripe/fixtures/create_charge.json
@@ -21,6 +21,13 @@
   "metadata": {
   },
   "order": null,
+  "outcome": {
+    "network_status": "approved_by_network",
+    "reason": null,
+    "risk_level": "normal",
+    "seller_message": "Payment complete.",
+    "type": "authorized"
+  },
   "paid": true,
   "receipt_email": null,
   "receipt_number": null,

--- a/lib/fake_stripe/fixtures/create_charge.json
+++ b/lib/fake_stripe/fixtures/create_charge.json
@@ -52,7 +52,7 @@
     "address_line2": null,
     "address_state": null,
     "address_zip": null,
-    "address_zip_check": null,
+    "address_zip_check": "pass",
     "brand": "Visa",
     "country": "US",
     "customer": "cus_7xeYRmuGuwvZK1",

--- a/lib/fake_stripe/fixtures/create_customer.json
+++ b/lib/fake_stripe/fixtures/create_customer.json
@@ -21,7 +21,7 @@
         "address_line2": null,
         "address_state": null,
         "address_zip": null,
-        "address_zip_check": null,
+        "address_zip_check": "pass",
         "brand": "Visa",
         "country": "US",
         "customer": "abcdefghijklmnop",

--- a/lib/fake_stripe/fixtures/list_cards.json
+++ b/lib/fake_stripe/fixtures/list_cards.json
@@ -23,7 +23,7 @@
     "address_country": null,
     "cvc_check": null,
     "address_line1_check": null,
-    "address_zip_check": null
+    "address_zip_check": "pass"
   },
   {
     "id": "card_103ewd2eZvKYlo2CzCsKfISG",
@@ -45,7 +45,7 @@
     "address_country": null,
     "cvc_check": null,
     "address_line1_check": null,
-    "address_zip_check": null
+    "address_zip_check": "pass"
   },
   {
     "id": "card_103ewd2eZvKYlo2CzCsKfISH",
@@ -67,7 +67,7 @@
     "address_country": null,
     "cvc_check": null,
     "address_line1_check": null,
-    "address_zip_check": null
+    "address_zip_check": "pass"
   }
   ]
 }

--- a/lib/fake_stripe/fixtures/list_charges.json
+++ b/lib/fake_stripe/fixtures/list_charges.json
@@ -32,7 +32,7 @@
         "address_country": null,
         "cvc_check": "pass",
         "address_line1_check": null,
-        "address_zip_check": null
+        "address_zip_check": "pass"
       },
       "captured": true,
       "refunds": [
@@ -84,7 +84,7 @@
         "address_country": null,
         "cvc_check": "pass",
         "address_line1_check": null,
-        "address_zip_check": null
+        "address_zip_check": "pass"
       },
       "captured": true,
       "refunds": [
@@ -129,7 +129,7 @@
         "address_country": null,
         "cvc_check": "pass",
         "address_line1_check": null,
-        "address_zip_check": null
+        "address_zip_check": "pass"
       },
       "captured": true,
       "refunds": [

--- a/lib/fake_stripe/fixtures/list_customers.json
+++ b/lib/fake_stripe/fixtures/list_customers.json
@@ -48,7 +48,7 @@
           "address_country": null,
           "cvc_check": "pass",
           "address_line1_check": null,
-          "address_zip_check": null
+          "address_zip_check": "pass"
         }
       ]
     },
@@ -99,7 +99,7 @@
           "address_country": null,
           "cvc_check": "pass",
           "address_line1_check": null,
-          "address_zip_check": null
+          "address_zip_check": "pass"
         }
       ]
     },
@@ -150,7 +150,7 @@
           "address_country": null,
           "cvc_check": "pass",
           "address_line1_check": null,
-          "address_zip_check": null
+          "address_zip_check": "pass"
         }
       ]
     },

--- a/lib/fake_stripe/fixtures/list_events.json
+++ b/lib/fake_stripe/fixtures/list_events.json
@@ -38,7 +38,7 @@
           "address_country": null,
           "cvc_check": "pass",
           "address_line1_check": null,
-          "address_zip_check": null
+          "address_zip_check": "pass"
         },
         "captured": true,
         "refunds": [
@@ -94,7 +94,7 @@
           "address_country": null,
           "cvc_check": "pass",
           "address_line1_check": null,
-          "address_zip_check": null
+          "address_zip_check": "pass"
         },
         "captured": true,
         "refunds": [
@@ -150,7 +150,7 @@
           "address_country": null,
           "cvc_check": "pass",
           "address_line1_check": null,
-          "address_zip_check": null
+          "address_zip_check": "pass"
         },
         "captured": true,
         "refunds": [

--- a/lib/fake_stripe/fixtures/refund_charge.json
+++ b/lib/fake_stripe/fixtures/refund_charge.json
@@ -39,6 +39,13 @@
       "balance_transaction": "txn_3ewdvdDggQXEhV"
     }
   ],
+  "outcome": {
+    "network_status": "approved_by_network",
+    "reason": null,
+    "risk_level": "normal",
+    "seller_message": "Payment complete.",
+    "type": "authorized"
+  },
   "balance_transaction": "txn_103cQg2eZvKYlo2CYKVlR2nh",
   "failure_message": null,
   "failure_code": null,

--- a/lib/fake_stripe/fixtures/refund_charge.json
+++ b/lib/fake_stripe/fixtures/refund_charge.json
@@ -27,7 +27,7 @@
     "address_country": null,
     "cvc_check": "pass",
     "address_line1_check": null,
-    "address_zip_check": null
+    "address_zip_check": "pass"
   },
   "captured": true,
   "refunds": [

--- a/lib/fake_stripe/fixtures/retrieve_card.json
+++ b/lib/fake_stripe/fixtures/retrieve_card.json
@@ -18,5 +18,5 @@
   "address_country": null,
   "cvc_check": null,
   "address_line1_check": null,
-  "address_zip_check": null
+  "address_zip_check": "pass"
 }

--- a/lib/fake_stripe/fixtures/retrieve_charge.json
+++ b/lib/fake_stripe/fixtures/retrieve_charge.json
@@ -33,6 +33,13 @@
   "refunds": [
 
   ],
+  "outcome": {
+    "network_status": "approved_by_network",
+    "reason": null,
+    "risk_level": "normal",
+    "seller_message": "Payment complete.",
+    "type": "authorized"
+  },
   "balance_transaction": "txn_103cQg2eZvKYlo2CYKVlR2nh",
   "failure_message": null,
   "failure_code": null,

--- a/lib/fake_stripe/fixtures/retrieve_charge.json
+++ b/lib/fake_stripe/fixtures/retrieve_charge.json
@@ -27,7 +27,7 @@
     "address_country": null,
     "cvc_check": "pass",
     "address_line1_check": null,
-    "address_zip_check": null
+    "address_zip_check": "pass"
   },
   "captured": true,
   "refunds": [

--- a/lib/fake_stripe/fixtures/retrieve_customer.json
+++ b/lib/fake_stripe/fixtures/retrieve_customer.json
@@ -21,7 +21,7 @@
         "address_line2": null,
         "address_state": null,
         "address_zip": null,
-        "address_zip_check": null,
+        "address_zip_check": "pass",
         "brand": "Visa",
         "country": "US",
         "customer": "abcdefghijklmnop",

--- a/lib/fake_stripe/fixtures/retrieve_event.json
+++ b/lib/fake_stripe/fixtures/retrieve_event.json
@@ -33,7 +33,7 @@
         "address_country": null,
         "cvc_check": "pass",
         "address_line1_check": null,
-        "address_zip_check": null
+        "address_zip_check": "pass"
       },
       "captured": true,
       "refunds": [

--- a/lib/fake_stripe/fixtures/update_card.json
+++ b/lib/fake_stripe/fixtures/update_card.json
@@ -18,5 +18,5 @@
   "address_country": null,
   "cvc_check": null,
   "address_line1_check": null,
-  "address_zip_check": null
+  "address_zip_check": "pass"
 }

--- a/lib/fake_stripe/fixtures/update_charge.json
+++ b/lib/fake_stripe/fixtures/update_charge.json
@@ -33,6 +33,13 @@
   "refunds": [
 
   ],
+  "outcome": {
+    "network_status": "approved_by_network",
+    "reason": null,
+    "risk_level": "normal",
+    "seller_message": "Payment complete.",
+    "type": "authorized"
+  },
   "balance_transaction": "txn_103cQg2eZvKYlo2CYKVlR2nh",
   "failure_message": null,
   "failure_code": null,

--- a/lib/fake_stripe/fixtures/update_charge.json
+++ b/lib/fake_stripe/fixtures/update_charge.json
@@ -27,7 +27,7 @@
     "address_country": null,
     "cvc_check": "pass",
     "address_line1_check": null,
-    "address_zip_check": null
+    "address_zip_check": "pass"
   },
   "captured": true,
   "refunds": [

--- a/lib/fake_stripe/fixtures/update_customer.json
+++ b/lib/fake_stripe/fixtures/update_customer.json
@@ -21,7 +21,7 @@
         "address_line2": null,
         "address_state": null,
         "address_zip": null,
-        "address_zip_check": null,
+        "address_zip_check": "pass",
         "brand": "Visa",
         "country": "US",
         "customer": "abcdefghijklmnop",


### PR DESCRIPTION
I created a pull request on thoughbot's `fake_stripe` gem and when I created the fork I wasn't paying attention and created it on my personal account. If we're going to maintain a fork for any length of time (which we shouldn't since this gem is all but deprecated), it should be under the Homechef umbrella.