### PR TITLE
update app to support newer versions of capybara

### DIFF
--- a/lib/fake_stripe/stub_stripe_js.rb
+++ b/lib/fake_stripe/stub_stripe_js.rb
@@ -24,7 +24,11 @@ module FakeStripe
 
     def self.boot(port = FakeStripe::Utils.find_available_port)
       instance = new
-      Capybara::Server.new(instance, port).tap { |server| server.boot }
+      if Capybara::VERSION > "3"
+        Capybara::Server.new(instance, port: port).tap { |server| server.boot }
+      else
+        Capybara::Server.new(instance, port).tap { |server| server.boot }
+      end
     end
 
     def self.boot_once

--- a/lib/fake_stripe/version.rb
+++ b/lib/fake_stripe/version.rb
@@ -1,3 +1,3 @@
 module FakeStripe
-  VERSION = '0.1.0'
+  VERSION = '0.2.0'
 end


### PR DESCRIPTION
The method of invoking capybara servers changes with the 3.0 major
release, which is itself pretty old by now. Regardless, support that
change.

We run this gem off master, so I'm going to update the version, but I
can't just update the dev dependencies as we essentially aren't using
gem versioning at all.