### PR TITLE
#18979 - Apple Pay - Updated json for tokenization method

### DIFF
--- a/lib/fake_stripe/fixtures/create_customer.json
+++ b/lib/fake_stripe/fixtures/create_customer.json
@@ -33,7 +33,7 @@
         "last4": "4242",
         "metadata": {},
         "name": null,
-        "tokenization_method": null
+        "tokenization_method": "apple_pay",
       }
     ],
     "has_more": false,
@@ -52,4 +52,4 @@
   "account_balance": 0,
   "currency": "usd",
   "default_source": "card_1234567890ABCDEFghijklmn"
-}
+},


### PR DESCRIPTION
Updates tokenization method for specs.
Not sure this is the correct change, since this change will only work for apple pay.
@rkillackey can we update this repo to have multiple users? Docs seem sparse or I'm not looking in the right place.

Progress towards #18979 Apple Pay Stripe